### PR TITLE
[PLFED-298] Produce proper signature references to both SAML 1.0/1.1 and SAML 2

### DIFF
--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/api/saml/v2/sig/SAML2Signature.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/api/saml/v2/sig/SAML2Signature.java
@@ -45,6 +45,7 @@ import org.picketlink.identity.federation.core.util.XMLSignatureUtil;
 import org.picketlink.identity.federation.saml.v2.protocol.RequestAbstractType;
 import org.picketlink.identity.federation.saml.v2.protocol.ResponseType;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -278,11 +279,18 @@ public class SAML2Signature {
      * method should be called before signing/validating a saml document.
      * </p>
      *
-     * @param signedDocument SAML document to have its ID attribute configured.
+     * @param document SAML document to have its ID attribute configured.
      */
-    private void configureIdAttribute(Document signedDocument) {
+    private void configureIdAttribute(Document document) {
         // Estabilish the IDness of the ID attribute.
-        signedDocument.getDocumentElement().setIdAttribute("ID", true);
+        document.getDocumentElement().setIdAttribute("ID", true);
+        NodeList nodes = document.getElementsByTagNameNS("urn:oasis:names:tc:SAML:2.0:assertion", "Assertion");
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node n = nodes.item(i);
+            if (n instanceof Element) {
+                ((Element)n).setIdAttribute("ID", true);
+            }
+        }
     }
 
     public Node getNextSiblingOfIssuer(Document doc) {

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/core/util/XMLSignatureUtil.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/core/util/XMLSignatureUtil.java
@@ -64,7 +64,10 @@ import org.picketlink.identity.federation.core.saml.v2.util.DocumentUtil;
 import org.picketlink.identity.federation.core.transfer.SignatureUtilTransferObject;
 import org.picketlink.identity.federation.core.wstrust.WSTrustConstants;
 import org.picketlink.identity.xmlsec.w3.xmldsig.SignatureType;
+import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -74,6 +77,7 @@ import org.xml.sax.SAXException;
  * "picketlink.xmlsig.canonicalization"
  *
  * @author Anil.Saldhana@redhat.com
+ * @author alessio.soldano@jboss.com
  * @since Dec 15, 2008
  */
 public class XMLSignatureUtil {
@@ -211,6 +215,9 @@ public class XMLSignatureUtil {
         Node signingNode = newDoc.importNode(nodeToBeSigned, true);
         newDoc.appendChild(signingNode);
 
+        if (!referenceURI.isEmpty()) {
+            propagateIDAttributeSetup(nodeToBeSigned, newDoc.getDocumentElement());
+        }
         newDoc = sign(newDoc, keyPair, digestMethod, signatureMethod, referenceURI);
 
         // if the signed element is a SAMLv2.0 assertion we need to move the signature element to the position
@@ -232,6 +239,24 @@ public class XMLSignatureUtil {
         // doc.getDocumentElement().replaceChild(signedNode, nodeToBeSigned);
 
         return doc;
+    }
+    
+    /**
+     * Setup the ID attribute into <code>destElement</code> depending on the
+     * <code>isId</code> flag of an attribute of <code>sourceNode</code>.
+     * 
+     * @param sourceNode
+     * @param destDocElement
+     */
+    public static void propagateIDAttributeSetup(Node sourceNode, Element destElement) {
+        NamedNodeMap nnm = sourceNode.getAttributes();
+        for (int i = 0; i < nnm.getLength(); i++) {
+            Attr attr = (Attr)nnm.item(i);
+            if (attr.isId()) {
+                destElement.setIdAttribute(attr.getName(), true); 
+                break;
+            }
+        }
     }
 
     /**

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/core/util/XMLSignatureUtil.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/core/util/XMLSignatureUtil.java
@@ -239,6 +239,10 @@ public class XMLSignatureUtil {
 
         // Now let us import this signed doc into the original document we got in the method call
         Node signedNode = doc.importNode(newDoc.getFirstChild(), true);
+        
+        if (!referenceURI.isEmpty()) {
+            propagateIDAttributeSetup(newDoc.getDocumentElement(), (Element)signedNode);
+        }
 
         parentNode.replaceChild(signedNode, nodeToBeSigned);
         // doc.getDocumentElement().replaceChild(signedNode, nodeToBeSigned);

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/api/saml/v2/SAML2ResponseUnitTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/api/saml/v2/SAML2ResponseUnitTestCase.java
@@ -34,6 +34,7 @@ import java.security.cert.Certificate;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.log4j.Logger;
 import org.junit.Test;
 import org.picketlink.identity.federation.api.saml.v2.response.SAML2Response;
 import org.picketlink.identity.federation.api.saml.v2.sig.SAML2Signature;
@@ -86,7 +87,7 @@ public class SAML2ResponseUnitTestCase {
         Document signedDoc = sig.sign((ResponseType) samlObject, getKeyPair());
         assertNotNull(signedDoc);
 
-        System.out.println("Signed Response=" + DocumentUtil.asString(signedDoc));
+        Logger.getLogger(SAML2ResponseUnitTestCase.class).debug("Signed Response=" + DocumentUtil.asString(signedDoc));
     }
 
     /**
@@ -127,7 +128,7 @@ public class SAML2ResponseUnitTestCase {
         Document signedDoc = sig.sign(responseType, getKeyPair());
         assertNotNull(signedDoc);
 
-        System.out.println("Signed Response=" + DocumentUtil.asString(signedDoc));
+        Logger.getLogger(SAML2ResponseUnitTestCase.class).debug("Signed Response=" + DocumentUtil.asString(signedDoc));
 
         Document convertedDoc = samlResponse.convert(responseType);
         assertNotNull(convertedDoc);

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/api/saml/v2/SignatureValidationUnitTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/api/saml/v2/SignatureValidationUnitTestCase.java
@@ -48,6 +48,7 @@ import org.picketlink.identity.federation.saml.v2.assertion.AuthnStatementType;
 import org.picketlink.identity.federation.saml.v2.protocol.AuthnRequestType;
 import org.picketlink.identity.federation.saml.v2.protocol.ResponseType;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 /**
@@ -197,6 +198,10 @@ public class SignatureValidationUnitTestCase {
         Document validatingDoc = DocumentUtil.createDocument();
         Node importedSignedNode = validatingDoc.importNode(signedNode.getOwnerDocument().getFirstChild(), true);
         validatingDoc.appendChild(importedSignedNode);
+        
+        //set IDness in validating document
+        Element assertionEl = (Element)DocumentUtil.getNodeWithAttribute(validatingDoc, "urn:oasis:names:tc:SAML:2.0:assertion", "Assertion", "ID", id);
+        assertionEl.setIdAttribute("ID", true);
 
         // Validate the signature
         boolean isValid = XMLSignatureUtil.validate(validatingDoc, kp.getPublic());
@@ -215,6 +220,10 @@ public class SignatureValidationUnitTestCase {
         validatingDoc = DocumentUtil.createDocument();
         importedSignedNode = validatingDoc.importNode(signedNode.getOwnerDocument().getFirstChild(), true);
         validatingDoc.appendChild(importedSignedNode);
+        
+        //set IDness in validating document
+        assertionEl = (Element)DocumentUtil.getNodeWithAttribute(validatingDoc, "urn:oasis:names:tc:SAML:2.0:assertion", "Assertion", "ID", id);
+        assertionEl.setIdAttribute("ID", true);
 
         // The client re-validates the signature.
         assertTrue("Signature is valid:", XMLSignatureUtil.validate(validatingDoc, kp.getPublic()));

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/api/saml/v2/SignatureValidationUnitTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/api/saml/v2/SignatureValidationUnitTestCase.java
@@ -30,6 +30,7 @@ import java.security.KeyPairGenerator;
 
 import javax.xml.crypto.dsig.SignatureMethod;
 
+import org.apache.log4j.Logger;
 import org.junit.Test;
 import org.picketlink.identity.federation.api.saml.v2.request.SAML2Request;
 import org.picketlink.identity.federation.api.saml.v2.response.SAML2Response;
@@ -78,7 +79,7 @@ public class SignatureValidationUnitTestCase {
         ss.setSignatureMethod(SignatureMethod.DSA_SHA1);
         Document signedDoc = ss.sign(authnRequest, kp);
 
-        System.out.println("Signed Doc:" + DocumentUtil.asString(signedDoc));
+        Logger.getLogger(SignatureValidationUnitTestCase.class).debug("Signed Doc:" + DocumentUtil.asString(signedDoc));
 
         JAXPValidationUtil.validate(DocumentUtil.getNodeAsStream(signedDoc));
 
@@ -111,7 +112,7 @@ public class SignatureValidationUnitTestCase {
         ss.setSignatureMethod(SignatureMethod.DSA_SHA1);
         Document signedDoc = ss.sign(authnRequest, kp);
 
-        System.out.println("Signed Doc:" + DocumentUtil.asString(signedDoc));
+        Logger.getLogger(SignatureValidationUnitTestCase.class).debug("Signed Doc:" + DocumentUtil.asString(signedDoc));
 
         JAXPValidationUtil.validate(DocumentUtil.getNodeAsStream(signedDoc));
 
@@ -151,7 +152,7 @@ public class SignatureValidationUnitTestCase {
         ss.setSignatureMethod(SignatureMethod.DSA_SHA1);
         Document signedDoc = ss.sign(responseType, kp);
 
-        System.out.println(DocumentUtil.asString(signedDoc));
+        Logger.getLogger(SignatureValidationUnitTestCase.class).debug(DocumentUtil.asString(signedDoc));
         JAXPValidationUtil.validate(DocumentUtil.getNodeAsStream(signedDoc));
 
         // Validate the signature

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/saml/SAML11AssertionParserTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/saml/SAML11AssertionParserTestCase.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.List;
 
+import org.apache.log4j.Logger;
 import org.junit.Test;
 import org.picketlink.identity.federation.core.parsers.saml.SAMLParser;
 import org.picketlink.identity.federation.core.saml.v1.writers.SAML11AssertionWriter;
@@ -94,7 +95,7 @@ public class SAML11AssertionParserTestCase extends AbstractParserTest {
         SAML11AssertionWriter writer = new SAML11AssertionWriter(StaxUtil.getXMLStreamWriter(baos));
         writer.write(assertion);
         String writtenString = new String(baos.toByteArray());
-        System.out.println(writtenString);
+        Logger.getLogger(SAML11AssertionParserTestCase.class).debug(writtenString);
         validateSchema(writtenString);
     }
 
@@ -158,7 +159,7 @@ public class SAML11AssertionParserTestCase extends AbstractParserTest {
         SAML11AssertionWriter writer = new SAML11AssertionWriter(StaxUtil.getXMLStreamWriter(baos));
         writer.write(assertion);
         String writtenString = new String(baos.toByteArray());
-        System.out.println(writtenString);
+        Logger.getLogger(SAML11AssertionParserTestCase.class).debug(writtenString);
         validateSchema(writtenString);
     }
 
@@ -187,7 +188,7 @@ public class SAML11AssertionParserTestCase extends AbstractParserTest {
         SAML11AssertionWriter writer = new SAML11AssertionWriter(StaxUtil.getXMLStreamWriter(baos));
         writer.write(assertion);
         String writtenString = new String(baos.toByteArray());
-        System.out.println(writtenString);
+        Logger.getLogger(SAML11AssertionParserTestCase.class).debug(writtenString);
         validateSchema(writtenString);
     }
 
@@ -265,7 +266,7 @@ public class SAML11AssertionParserTestCase extends AbstractParserTest {
         SAML11AssertionWriter writer = new SAML11AssertionWriter(StaxUtil.getXMLStreamWriter(baos));
         writer.write(assertion);
         String writtenString = new String(baos.toByteArray());
-        System.out.println(writtenString);
+        Logger.getLogger(SAML11AssertionParserTestCase.class).debug(writtenString);
         validateSchema(writtenString);
     }
 
@@ -307,7 +308,7 @@ public class SAML11AssertionParserTestCase extends AbstractParserTest {
         SAML11AssertionWriter writer = new SAML11AssertionWriter(StaxUtil.getXMLStreamWriter(baos));
         writer.write(assertion);
         String writtenString = new String(baos.toByteArray());
-        System.out.println(writtenString);
+        Logger.getLogger(SAML11AssertionParserTestCase.class).debug(writtenString);
         validateSchema(writtenString);
     }
 }

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/saml/SAML11ResponseParserTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/saml/SAML11ResponseParserTestCase.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.util.List;
 
+import org.apache.log4j.Logger;
 import org.junit.Test;
 import org.picketlink.identity.federation.core.parsers.saml.SAML11ResponseParser;
 import org.picketlink.identity.federation.core.parsers.saml.SAMLParser;
@@ -76,7 +77,7 @@ public class SAML11ResponseParserTestCase extends AbstractParserTest {
         SAML11ResponseWriter writer = new SAML11ResponseWriter(StaxUtil.getXMLStreamWriter(baos));
         writer.write(response);
         String writtenString = new String(baos.toByteArray());
-        System.out.println(writtenString);
+        Logger.getLogger(SAML11ResponseParserTestCase.class).debug(writtenString);
         validateSchema(writtenString);
     }
 }

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/saml/SAMLAssertionParserTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/saml/SAMLAssertionParserTestCase.java
@@ -33,6 +33,7 @@ import java.util.Set;
 
 import javax.xml.namespace.QName;
 
+import org.apache.log4j.Logger;
 import org.junit.Test;
 import org.picketlink.identity.federation.core.parsers.saml.SAMLParser;
 import org.picketlink.identity.federation.core.saml.v2.constants.JBossSAMLConstants;
@@ -94,7 +95,7 @@ public class SAMLAssertionParserTestCase extends AbstractParserTest {
         SAMLAssertionWriter writer = new SAMLAssertionWriter(StaxUtil.getXMLStreamWriter(baos));
         writer.write(assertion);
         String writtenString = new String(baos.toByteArray());
-        System.out.println(writtenString);
+        Logger.getLogger(SAMLAssertionParserTestCase.class).debug(writtenString);
         validateSchema(writtenString);
     }
 
@@ -142,7 +143,7 @@ public class SAMLAssertionParserTestCase extends AbstractParserTest {
         SAMLAssertionWriter writer = new SAMLAssertionWriter(StaxUtil.getXMLStreamWriter(baos));
         writer.write(assertion);
         String writtenString = new String(baos.toByteArray());
-        System.out.println(writtenString);
+        Logger.getLogger(SAMLAssertionParserTestCase.class).debug(writtenString);
         validateSchema(writtenString);
     }
 
@@ -222,7 +223,7 @@ public class SAMLAssertionParserTestCase extends AbstractParserTest {
         DocumentUtil.getDocument(bis); // throws exceptions
 
         String writtenString = new String(bytes);
-        System.out.println(writtenString);
+        Logger.getLogger(SAMLAssertionParserTestCase.class).debug(writtenString);
         validateSchema(writtenString);
     }
 

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/saml/SAMLAuthnRequestParserTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/saml/SAMLAuthnRequestParserTestCase.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 
+import org.apache.log4j.Logger;
 import org.junit.Test;
 import org.picketlink.identity.federation.core.parsers.saml.SAMLParser;
 import org.picketlink.identity.federation.core.saml.v2.util.DocumentUtil;
@@ -117,7 +118,7 @@ public class SAMLAuthnRequestParserTestCase extends AbstractParserTest {
         writer.write(authnRequest);
 
         byte[] data = baos.toByteArray();
-        System.out.println(new String(data));
+        Logger.getLogger(SAMLAuthnRequestParserTestCase.class).debug(new String(data));
         ByteArrayInputStream bis = new ByteArrayInputStream(data);
         Document doc = DocumentUtil.getDocument(bis); // throws exceptions
         JAXPValidationUtil.validate(DocumentUtil.getNodeAsStream(doc));

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/saml/SAMLResponseParserTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/saml/SAMLResponseParserTestCase.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.log4j.Logger;
 import org.junit.Test;
 import org.picketlink.identity.federation.core.parsers.saml.SAMLParser;
 import org.picketlink.identity.federation.core.saml.v2.constants.JBossSAMLURIConstants;
@@ -137,7 +138,7 @@ public class SAMLResponseParserTestCase extends AbstractParserTest {
         writer = new SAMLResponseWriter(StaxUtil.getXMLStreamWriter(baos));
         writer.write(response);
         String writtenString = new String(baos.toByteArray());
-        System.out.println(writtenString);
+        Logger.getLogger(SAMLResponseParserTestCase.class).debug(writtenString);
         validateSchema(writtenString);
     }
 
@@ -211,7 +212,7 @@ public class SAMLResponseParserTestCase extends AbstractParserTest {
         SAMLResponseWriter writer = new SAMLResponseWriter(StaxUtil.getXMLStreamWriter(baos));
         writer.write(response);
         String writtenString = new String(baos.toByteArray());
-        System.out.println(writtenString);
+        Logger.getLogger(SAMLResponseParserTestCase.class).debug(writtenString);
         validateSchema(writtenString);
     }
 
@@ -241,7 +242,7 @@ public class SAMLResponseParserTestCase extends AbstractParserTest {
         SAMLResponseWriter writer = new SAMLResponseWriter(StaxUtil.getXMLStreamWriter(baos));
         writer.write(response);
         String writtenString = new String(baos.toByteArray());
-        System.out.println(writtenString);
+        Logger.getLogger(SAMLResponseParserTestCase.class).debug(writtenString);
         validateSchema(writtenString);
     }
 
@@ -287,7 +288,7 @@ public class SAMLResponseParserTestCase extends AbstractParserTest {
         SAMLResponseWriter writer = new SAMLResponseWriter(StaxUtil.getXMLStreamWriter(baos));
         writer.write(response);
         String writtenString = new String(baos.toByteArray());
-        System.out.println(writtenString);
+        Logger.getLogger(SAMLResponseParserTestCase.class).debug(writtenString);
         validateSchema(writtenString);
     }
 

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/saml/SAMLSloRequestParserTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/saml/SAMLSloRequestParserTestCase.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 
+import org.apache.log4j.Logger;
 import org.junit.Test;
 import org.picketlink.identity.federation.core.parsers.saml.SAMLParser;
 import org.picketlink.identity.federation.core.saml.v2.util.DocumentUtil;
@@ -72,7 +73,7 @@ public class SAMLSloRequestParserTestCase extends AbstractParserTest {
         writer = new SAMLRequestWriter(StaxUtil.getXMLStreamWriter(baos));
         writer.write(lotRequest);
         String writtenString = new String(baos.toByteArray());
-        System.out.println(writtenString);
+        Logger.getLogger(SAMLSloRequestParserTestCase.class).debug(writtenString);
         validateSchema(writtenString);
     }
 
@@ -101,7 +102,7 @@ public class SAMLSloRequestParserTestCase extends AbstractParserTest {
         writer = new SAMLRequestWriter(StaxUtil.getXMLStreamWriter(baos));
         writer.write(lotRequest);
         String writtenString = new String(baos.toByteArray());
-        System.out.println(writtenString);
+        Logger.getLogger(SAMLSloRequestParserTestCase.class).debug(writtenString);
         validateSchema(writtenString);
     }
 }

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/saml/SAMLSloResponseParserTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/saml/SAMLSloResponseParserTestCase.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 
 import javax.xml.namespace.QName;
 
+import org.apache.log4j.Logger;
 import org.junit.Test;
 import org.picketlink.identity.federation.core.parsers.saml.SAMLParser;
 import org.picketlink.identity.federation.core.saml.v2.util.DocumentUtil;
@@ -82,7 +83,7 @@ public class SAMLSloResponseParserTestCase extends AbstractParserTest {
         writer = new SAMLResponseWriter(StaxUtil.getXMLStreamWriter(baos));
         writer.write(response, new QName(PROTOCOL_NSURI.get(), LOGOUT_RESPONSE.get(), "samlp"));
         String writtenString = new String(baos.toByteArray());
-        System.out.println(writtenString);
+        Logger.getLogger(SAMLSloResponseParserTestCase.class).debug(writtenString);
         validateSchema(writtenString);
     }
 

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/wst/WSTrustBatchValidateParsingTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/wst/WSTrustBatchValidateParsingTestCase.java
@@ -29,6 +29,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.util.List;
 
+import org.apache.log4j.Logger;
 import org.junit.Test;
 import org.picketlink.identity.federation.core.parsers.wst.WSTrustParser;
 import org.picketlink.identity.federation.core.saml.v2.util.DocumentUtil;
@@ -77,7 +78,7 @@ public class WSTrustBatchValidateParsingTestCase {
         Document doc = DocumentUtil.getDocument(new ByteArrayInputStream(baos.toByteArray()));
         baos.close();
 
-        System.out.println(DocumentUtil.asString(doc));
+        Logger.getLogger(WSTrustBatchValidateParsingTestCase.class).debug(DocumentUtil.asString(doc));
 
         JAXPValidationUtil.validate(DocumentUtil.getNodeAsStream(doc));
     }

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/wst/WSTrustRenewTargetParsingTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/wst/WSTrustRenewTargetParsingTestCase.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 
+import org.apache.log4j.Logger;
 import org.junit.Test;
 import org.picketlink.identity.federation.core.parsers.wst.WSTrustParser;
 import org.picketlink.identity.federation.core.saml.v2.util.DocumentUtil;
@@ -98,7 +99,7 @@ public class WSTrustRenewTargetParsingTestCase {
         rstrWriter.write(responseCollection);
 
         byte[] data = baos.toByteArray();
-        System.out.println(new String(data));
+        Logger.getLogger(WSTrustRenewTargetParsingTestCase.class).debug(new String(data));
         Document doc = DocumentUtil.getDocument(new ByteArrayInputStream(data));
         JAXPValidationUtil.validate(DocumentUtil.getNodeAsStream(doc));
     }

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/wst/WSTrustSecondaryParametersTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/wst/WSTrustSecondaryParametersTestCase.java
@@ -6,6 +6,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 
+import org.apache.log4j.Logger;
 import org.junit.Test;
 import org.picketlink.identity.federation.core.parsers.wst.WSTrustParser;
 import org.picketlink.identity.federation.core.saml.v2.util.DocumentUtil;
@@ -45,7 +46,7 @@ public class WSTrustSecondaryParametersTestCase {
         rstWriter.write(requestToken);
 
         byte[] data = baos.toByteArray();
-        System.out.println(new String(data));
+        Logger.getLogger(WSTrustSecondaryParametersTestCase.class).debug(new String(data));
         Document doc = DocumentUtil.getDocument(new ByteArrayInputStream(data));
         JAXPValidationUtil.validate(DocumentUtil.getNodeAsStream(doc));
     }

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/util/XMLSignatureUtilUnitTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/util/XMLSignatureUtilUnitTestCase.java
@@ -30,6 +30,7 @@ import java.security.KeyPair;
 import javax.xml.crypto.dsig.DigestMethod;
 import javax.xml.crypto.dsig.SignatureMethod;
 
+import org.apache.log4j.Logger;
 import org.junit.Test;
 import org.picketlink.identity.federation.core.saml.v2.util.DocumentUtil;
 import org.picketlink.identity.federation.core.util.KeyStoreUtil;
@@ -79,7 +80,7 @@ public class XMLSignatureUtilUnitTestCase {
 
         assertNotNull(rstrDocument);
 
-        System.out.println(DocumentUtil.asString(rstrDocument));
+        Logger.getLogger(XMLSignatureUtilUnitTestCase.class).debug(DocumentUtil.asString(rstrDocument));
 
         assertTrue(XMLSignatureUtil.validate(rstrDocument, keyPair.getPublic()));
     }
@@ -103,7 +104,7 @@ public class XMLSignatureUtilUnitTestCase {
 
         assertNotNull(rstrDocument);
 
-        System.out.println(DocumentUtil.asString(rstrDocument));
+        Logger.getLogger(XMLSignatureUtilUnitTestCase.class).debug(DocumentUtil.asString(rstrDocument));
 
         assertTrue(XMLSignatureUtil.validate(rstrDocument, keyPair.getPublic()));
     }

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/util/XMLSignatureUtilUnitTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/util/XMLSignatureUtilUnitTestCase.java
@@ -68,6 +68,7 @@ public class XMLSignatureUtilUnitTestCase {
             Node theNode = childNodes.item(i);
             if (theNode instanceof Element) {
                 tokenElement = (Element) theNode;
+                tokenElement.setIdAttribute("AssertionID", true);
                 break;
             }
         }
@@ -76,7 +77,7 @@ public class XMLSignatureUtilUnitTestCase {
         KeyPair keyPair = KeyStoreUtil.generateKeyPair("RSA");
 
         rstrDocument = XMLSignatureUtil.sign(rstrDocument, tokenElement, keyPair, DigestMethod.SHA1, signatureMethod, "#"
-                + tokenElement.getAttribute("ID"));
+                + tokenElement.getAttribute("AssertionID"));
 
         assertNotNull(rstrDocument);
 

--- a/picketlink-core/src/test/resources/log4j.xml
+++ b/picketlink-core/src/test/resources/log4j.xml
@@ -47,7 +47,7 @@
   <!-- ============================== -->
 
   <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
-    <param name="Threshold" value="TRACE"/>
+    <param name="Threshold" value="INFO"/>
     <param name="Target" value="System.out"/>
 
     <layout class="org.apache.log4j.PatternLayout">

--- a/picketlink-core/src/test/resources/signatures/wstRequestCollection.xml
+++ b/picketlink-core/src/test/resources/signatures/wstRequestCollection.xml
@@ -15,7 +15,7 @@
 		</wst:KeyType>
 		<wst:RequestedSecurityToken>
 		   <saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion"
-				ID="ID_4756863b-eb25-4572-935f-af4ccc8a34ac" IssueInstant="2012-02-24T15:57:15.975Z"
+				AssertionID="ID_4756863b-eb25-4572-935f-af4ccc8a34ac" IssueInstant="2012-02-24T15:57:15.975Z"
 				Issuer="PicketLinkSTS" MajorVersion="1" MinorVersion="1">
 				<saml:Conditions NotBefore="2012-02-24T15:57:15.975Z"
 					NotOnOrAfter="2012-02-24T17:57:15.975Z" />


### PR DESCRIPTION
- [PLFED-298] Produce proper signature references to both SAML 1.0/1.1 and SAML 2
- Testsuite: removing extremely verbose xml messages from console (they're still logged using log4j into test.log file)
