### PR TITLE
PLFED-334, PLFED-335, PLFED-336, PLFED-337, PLFED-338

### DIFF
--- a/picketlink-bindings/picketlink-tomcat-common/src/main/java/org/picketlink/identity/federation/bindings/tomcat/idp/AbstractIDPValve.java
+++ b/picketlink-bindings/picketlink-tomcat-common/src/main/java/org/picketlink/identity/federation/bindings/tomcat/idp/AbstractIDPValve.java
@@ -598,11 +598,11 @@ public abstract class AbstractIDPValve extends ValveBase {
         } finally {
             try {
                 // if the destination is null, probably because some error occur during authentication, use the AuthnRequest
-                // issuer as the destination
+                // AssertionConsumerServiceURL as the destination
                 if (destination == null && samlObject instanceof AuthnRequestType) {
                     AuthnRequestType authRequest = (AuthnRequestType) samlObject;
 
-                    destination = authRequest.getIssuer().getValue();
+                    destination = authRequest.getAssertionConsumerServiceURL().toASCIIString();
                 }
 
                 boolean postProfile = webRequestUtil.hasSAMLRequestInPostProfile();

--- a/picketlink-bindings/picketlink-tomcat5/src/test/java/org/picketlink/test/identity/federation/bindings/authenticators/idp/TestIdentityParticipantStack.java
+++ b/picketlink-bindings/picketlink-tomcat5/src/test/java/org/picketlink/test/identity/federation/bindings/authenticators/idp/TestIdentityParticipantStack.java
@@ -35,7 +35,7 @@ public class TestIdentityParticipantStack implements IdentityParticipantStack {
     private static IdentityServer.STACK delegate = createDelegate();
     
     private static STACK createDelegate() {
-        return new IdentityServer().new STACK();
+        return new IdentityServer.STACK();
     }
     
     public static IdentityParticipantStack getDelegate() {

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/api/saml/v2/response/SAML2Response.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/api/saml/v2/response/SAML2Response.java
@@ -281,7 +281,7 @@ public class SAML2Response {
             
             //Add conditions -> AudienceRestriction
             AudienceRestrictionType audience = new AudienceRestrictionType();
-            audience.addAudience(URI.create(sp.getResponseDestinationURI()));
+            audience.addAudience(URI.create(sp.getIssuer()));
             conditions.addCondition(audience);
         }
 

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/core/parsers/saml/SAMLStatusResponseTypeParser.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/core/parsers/saml/SAMLStatusResponseTypeParser.java
@@ -131,7 +131,9 @@ public abstract class SAMLStatusResponseTypeParser {
                 if (startElement == null) {
                     // Go to Status code end element.
                     EndElement endElement = StaxParserUtil.getNextEndElement(xmlEventReader);
-                    StaxParserUtil.validate(endElement, JBossSAMLConstants.STATUS_CODE.get());
+                    if (endElement != null) {
+                        StaxParserUtil.validate(endElement, JBossSAMLConstants.STATUS_CODE.get());
+                    }
                     continue;
                 }
                 elementTag = startElement.getName().getLocalPart();

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/core/saml/v2/holders/SPInfoHolder.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/core/saml/v2/holders/SPInfoHolder.java
@@ -35,6 +35,7 @@ package org.picketlink.identity.federation.core.saml.v2.holders;
 public class SPInfoHolder {
     private String requestID;
     private String responseDestinationURI;
+    private String issuer;
 
     public String getRequestID() {
         return requestID;
@@ -50,5 +51,13 @@ public class SPInfoHolder {
 
     public void setResponseDestinationURI(String responseDestinationURI) {
         this.responseDestinationURI = responseDestinationURI;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public void setIssuer(String issuer) {
+        this.issuer = issuer;
     }
 }

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/web/core/IdentityServer.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/web/core/IdentityServer.java
@@ -60,7 +60,7 @@ public class IdentityServer implements HttpSessionListener {
 
     private IdentityParticipantStack stack = new STACK();
 
-    public class STACK implements IdentityParticipantStack {
+    public static class STACK implements IdentityParticipantStack {
         private final ConcurrentHashMap<String, Stack<String>> sessionParticipantsMap = new ConcurrentHashMap<String, Stack<String>>();
 
         private final ConcurrentHashMap<String, Set<String>> inTransitMap = new ConcurrentHashMap<String, Set<String>>();

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/web/handlers/saml2/SAML2AuthenticationHandler.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/web/handlers/saml2/SAML2AuthenticationHandler.java
@@ -257,6 +257,7 @@ public class SAML2AuthenticationHandler extends BaseSAML2Handler {
             SPInfoHolder sp = new SPInfoHolder();
             sp.setResponseDestinationURI(assertionConsumerURL);
             sp.setRequestID(requestID);
+            sp.setIssuer(art.getIssuer().getValue());
             responseType = saml2Response.createResponseType(id, sp, idp, issuerHolder);
 
             // Add information on the roles

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/web/util/IDPWebRequestUtil.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/web/util/IDPWebRequestUtil.java
@@ -235,20 +235,9 @@ public class IDPWebRequestUtil {
                log.trace("Redirecting to=" + finalDest);
             HTTPRedirectUtil.sendRedirectForResponder(finalDest, response);
         } else {
-            // If we support signature, we will sign message but only for error response.
-            // Normal response is already signed thanks to SAML2SignatureGenerationHandler
-            if (supportSignature && isErrorResponse) {
-                // Sign the document
-                SAML2Signature samlSignature = new SAML2Signature();
 
-                Node nextSibling = samlSignature.getNextSiblingOfIssuer(responseDoc);
-                samlSignature.setNextSibling(nextSibling);
-                KeyPair keypair = keyManager.getSigningKeyPair();
-                samlSignature.signSAMLDocument(responseDoc, keypair);
-
-                if (trace)
-                    log.trace("Sending over to SP:" + DocumentUtil.asString(responseDoc));
-            }
+            if (trace)
+               log.trace("Sending over to SP:" + DocumentUtil.asString(responseDoc));
             byte[] responseBytes = DocumentUtil.getDocumentAsString(responseDoc).getBytes("UTF-8");
 
             String samlResponse = PostBindingUtil.base64Encode(new String(responseBytes));

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/api/saml/v2/SAML2AuthnResponseUnitTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/api/saml/v2/SAML2AuthnResponseUnitTestCase.java
@@ -58,6 +58,7 @@ public class SAML2AuthnResponseUnitTestCase {
 
         SPInfoHolder sp = new SPInfoHolder();
         sp.setResponseDestinationURI("http://fakesp");
+        sp.setIssuer("http://fakesp");
         ResponseType rt = saml2Response.createResponseType("response111", sp, idp, issuerHolder);
         Assert.assertNotNull(rt);
 

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/api/util/XMLEncryptionUnitTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/api/util/XMLEncryptionUnitTestCase.java
@@ -171,6 +171,7 @@ public class XMLEncryptionUnitTestCase extends TestCase {
 
         SPInfoHolder sp = new SPInfoHolder();
         sp.setResponseDestinationURI("http://service");
+        sp.setIssuer("http://service.issuer");
         responseType = saml2Response.createResponseType(id, sp, idp, issuerHolder);
         AssertionType assertion = responseType.getAssertions().get(0).getAssertion();
 

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/saml/SAMLSloResponseParserTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/parser/saml/SAMLSloResponseParserTestCase.java
@@ -23,6 +23,7 @@ package org.picketlink.test.identity.federation.core.parser.saml;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.picketlink.identity.federation.core.saml.v2.constants.JBossSAMLConstants.LOGOUT_RESPONSE;
 import static org.picketlink.identity.federation.core.saml.v2.constants.JBossSAMLURIConstants.PROTOCOL_NSURI;
 
@@ -107,5 +108,27 @@ public class SAMLSloResponseParserTestCase extends AbstractParserTest {
         StatusType status = response.getStatus();
         assertEquals("urn:oasis:names:tc:SAML:2.0:status:Responder", status.getStatusCode().getValue().toString());
         assertEquals("urn:oasis:names:tc:SAML:2.0:status:Success", status.getStatusCode().getStatusCode().getValue().toString());
+    }
+
+    @Test
+    public void testSLOResponseFromSalesforce() throws Exception {
+        ClassLoader tcl = Thread.currentThread().getContextClassLoader();
+        InputStream configStream = tcl.getResourceAsStream("parser/saml2/saml2-logout-response-salesforce.xml");
+
+        SAMLParser parser = new SAMLParser();
+        StatusResponseType response = (StatusResponseType) parser.parse(configStream);
+        assertNotNull("ResponseType is not null", response);
+
+        assertEquals(XMLTimeUtil.parse("2012-06-08T10:00:31.924Z"), response.getIssueInstant());
+        assertEquals("2.0", response.getVersion());
+        assertEquals("_580ef9943601e7d453514edab43ff2d01339149631922", response.getID());
+
+        // Issuer
+        assertEquals("https://saml.salesforce.com", response.getIssuer().getValue());
+
+        // Status
+        StatusType status = response.getStatus();
+        assertEquals("urn:oasis:names:tc:SAML:2.0:status:Success", status.getStatusCode().getValue().toString());
+        assertNull(status.getStatusCode().getStatusCode());
     }
 }

--- a/picketlink-core/src/test/resources/parser/saml2/saml2-logout-response-salesforce.xml
+++ b/picketlink-core/src/test/resources/parser/saml2/saml2-logout-response-salesforce.xml
@@ -1,0 +1,75 @@
+<samlp:LogoutResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                      Destination="http://localhost:8080/idp-sig/"
+                      ID="_580ef9943601e7d453514edab43ff2d01339149631922"
+                      InResponseTo="ID_4a286ceb-9c57-45cc-bb6d-a7fdb4f97101"
+                      IssueInstant="2012-06-08T10:00:31.924Z"
+                      Version="2.0"
+      >
+   <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">https://saml.salesforce.com</saml:Issuer>
+   <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+      <ds:SignedInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+         <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"
+                                    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+               />
+         <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"
+                             xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+               />
+         <ds:Reference URI="#_580ef9943601e7d453514edab43ff2d01339149631922"
+                       xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+               >
+            <ds:Transforms xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+               <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"
+                             xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                     />
+               <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"
+                             xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                     >
+                  <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#"
+                                          PrefixList="ds saml samlp"
+                        />
+               </ds:Transform>
+            </ds:Transforms>
+            <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"
+                             xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                  />
+            <ds:DigestValue xmlns:ds="http://www.w3.org/2000/09/xmldsig#">cai/f88sZ2Q8OhkSAqrXfl4b0T0=</ds:DigestValue>
+         </ds:Reference>
+      </ds:SignedInfo>
+      <ds:SignatureValue xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+         Xp7SHN/KlJ6uurZ6Q0u+Qp9h0R+ZN5ABhHKgvn9/Bz1rGf/tZQp5yqIf9yM2ppQbkS8ZZb3MGF46
+         sGkC1j0zUyiKQAQHVPpAPvjfs8Mqug0fK9BGTIeQ1KGmO8atv33RLcAwGa3HH0oYzXV+Gwj1ALt8
+         HhwVRf1wMnWTCdNho4Y=
+      </ds:SignatureValue>
+      <ds:KeyInfo>
+         <ds:X509Data>
+            <ds:X509Certificate>MIIFBzCCA++gAwIBAgIQDJ4ihF+4VYzLxb+qASp7IzANBgkqhkiG9w0BAQUFADCBvDELMAkGA1UE
+               BhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMR8wHQYDVQQLExZWZXJpU2lnbiBUcnVzdCBO
+               ZXR3b3JrMTswOQYDVQQLEzJUZXJtcyBvZiB1c2UgYXQgaHR0cHM6Ly93d3cudmVyaXNpZ24uY29t
+               L3JwYSAoYykxMDE2MDQGA1UEAxMtVmVyaVNpZ24gQ2xhc3MgMyBJbnRlcm5hdGlvbmFsIFNlcnZl
+               ciBDQSAtIEczMB4XDTExMTIwNzAwMDAwMFoXDTEzMTIwNzIzNTk1OVowgY4xCzAJBgNVBAYTAlVT
+               MRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHFA1TYW4gRnJhbmNpc2NvMR0wGwYDVQQKFBRT
+               YWxlc2ZvcmNlLmNvbSwgSW5jLjEUMBIGA1UECxQLQXBwbGljYXRpb24xHTAbBgNVBAMUFHByb3h5
+               LnNhbGVzZm9yY2UuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDMoSWW4dBiVScWbXno
+               3C6n2+qR/0O+eE4lzT0Y1go53Pk+Skn9sUu43Z+uZ8lOXDqmLiScTaB43ePbqIAUYimqCR9aYCLm
+               SeNwhs68dsxcyDVqm5XIr2OZsrLikhNkKPno+0fuoyOWbA35kRxBFXL66tEYlF8ETIT6G3kqt7CG
+               VwIDAQABo4IBszCCAa8wCQYDVR0TBAIwADALBgNVHQ8EBAMCBaAwQQYDVR0fBDowODA2oDSgMoYw
+               aHR0cDovL1NWUkludGwtRzMtY3JsLnZlcmlzaWduLmNvbS9TVlJJbnRsRzMuY3JsMEQGA1UdIAQ9
+               MDswOQYLYIZIAYb4RQEHFwMwKjAoBggrBgEFBQcCARYcaHR0cHM6Ly93d3cudmVyaXNpZ24uY29t
+               L3JwYTAoBgNVHSUEITAfBglghkgBhvhCBAEGCCsGAQUFBwMBBggrBgEFBQcDAjByBggrBgEFBQcB
+               AQRmMGQwJAYIKwYBBQUHMAGGGGh0dHA6Ly9vY3NwLnZlcmlzaWduLmNvbTA8BggrBgEFBQcwAoYw
+               aHR0cDovL1NWUkludGwtRzMtYWlhLnZlcmlzaWduLmNvbS9TVlJJbnRsRzMuY2VyMG4GCCsGAQUF
+               BwEMBGIwYKFeoFwwWjBYMFYWCWltYWdlL2dpZjAhMB8wBwYFKw4DAhoEFEtruSiWBgy70FI4myms
+               SweLIQUYMCYWJGh0dHA6Ly9sb2dvLnZlcmlzaWduLmNvbS92c2xvZ28xLmdpZjANBgkqhkiG9w0B
+               AQUFAAOCAQEAVq0AapffwqicpyAu41f5pWDn7FPjgIt6lirqwo7tLRMpxFuYKIMg+wvioJQ8DJ8m
+               Nyw+JnZDPxdVjDSkE2Lb+5Z5P9vKbD833jqKP5vniMMvHRftlkCqP/AI/9z6jomgQtfm3WbI7elT
+               FJvDwA+/VdxgU86mKRpalMWDB545GxVFiO6AZ/8dvApoHVHTQBfrckk9JCrH++Wq3EmErKcxzsY8
+               LItC8qCl5HtgJy160fII0ZdF8hV5vKlrHQpo91L0c1pn+z5RB+kt8GIreME2rU3WEmtZglBKrlw3
+               ik0sXL2CO/GCAzbh7YWkEfXtE3GcGh7NxcHB+08lZiJzKwN/yg==</ds:X509Certificate>
+         </ds:X509Data>
+      </ds:KeyInfo>
+   </ds:Signature>
+   <samlp:Status>
+      <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
+   </samlp:Status>
+</samlp:LogoutResponse>
+


### PR DESCRIPTION
PLFED-334:
During creation of error response on IDP side is response signed first time in webRequestUtil.getErrorResponse and second time in webRequestUtil.send. Second case is not needed.

I removed the signature related code snipet from IDPWebRequestUtil.send because document should be already signed at this stage for both normal response and error response.

PLFED-335:
I've updated the valve to use assertionConsumerServiceURL instead of issuer. I also updated unit test IDPWebBrowserSSOTestCase epsecially the test "testRequestFromInvalidValidatingAlias()" to ensure that error response will use assertionConsumerServiceURL and not issuer

PLFED-336:
I am attaching commit for using value of "issuer" instead of "assertionConsumerServiceURL" for content of audience. Maybe it's possible to make it configurable so that people can choose what they will use as content of AudienceRestriction. But for now, I am using issuer.

PLFED-337:
I am adding unit test for parsing SAML Logout response from salesforce. This test can be used for simulate NPE issue described in JIRA PLFED-337. I am also adding fix for this issue in class "SamlStatusResponseTypeParser"
