### PR TITLE
PLFED-340, PLFED-341

### DIFF
--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/core/saml/v2/util/XMLTimeUtil.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/core/saml/v2/util/XMLTimeUtil.java
@@ -32,6 +32,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.picketlink.identity.federation.core.exceptions.ConfigurationException;
 import org.picketlink.identity.federation.core.exceptions.ParsingException;
+import org.picketlink.identity.federation.web.constants.GeneralConstants;
 
 /**
  * Util class dealing with xml based time
@@ -105,9 +106,21 @@ public class XMLTimeUtil {
      * @throws ConfigurationException
      */
     public static XMLGregorianCalendar getIssueInstant() throws ConfigurationException {
-        return getIssueInstant(TimeZone.getTimeZone("GMT").getID());
+        return getIssueInstant(getCurrentTimeZoneID());
     }
 
+    public static String getCurrentTimeZoneID() {
+       String timezonePropertyValue = SecurityActions.getSystemProperty(GeneralConstants.TIMEZONE, "GMT");
+
+       TimeZone timezone;
+       if (GeneralConstants.TIMEZONE_DEFAULT.equals(timezonePropertyValue)) {
+          timezone = TimeZone.getDefault();
+       } else {
+          timezone = TimeZone.getTimeZone(timezonePropertyValue);
+       }
+
+       return timezone.getID();
+    }
     /**
      * Convert the minutes into miliseconds
      *

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/core/saml/v2/util/XMLTimeUtil.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/core/saml/v2/util/XMLTimeUtil.java
@@ -105,7 +105,7 @@ public class XMLTimeUtil {
      * @throws ConfigurationException
      */
     public static XMLGregorianCalendar getIssueInstant() throws ConfigurationException {
-        return getIssueInstant(TimeZone.getDefault().getID());
+        return getIssueInstant(TimeZone.getTimeZone("GMT").getID());
     }
 
     /**

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/web/constants/GeneralConstants.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/web/constants/GeneralConstants.java
@@ -105,7 +105,11 @@ public interface GeneralConstants {
 
     String SAML_IDP_STRICT_POST_BINDING = "SAML_IDP_STRICT_POST_BINDING";
 
-    String DECRYPTING_KEY = "DECRYPTING_KEY";
+    String TIMEZONE = "picketlink.timezone";
+
+    String TIMEZONE_DEFAULT = "TIMEZONE_DEFAULT";
+
+   String DECRYPTING_KEY = "DECRYPTING_KEY";
 
     String SENDER_PUBLIC_KEY = "SENDER_PUBLIC_KEY";
 

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/web/handlers/saml2/SAML2IssuerTrustHandler.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/web/handlers/saml2/SAML2IssuerTrustHandler.java
@@ -22,6 +22,7 @@
 package org.picketlink.identity.federation.web.handlers.saml2;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -197,7 +198,15 @@ public class SAML2IssuerTrustHandler extends BaseSAML2Handler {
      * @throws IOException
      */
     private static String getDomain(String domainURL) throws IOException {
-        URL url = new URL(domainURL);
-        return url.getHost();
+       try {
+          URL url = new URL(domainURL);
+          return url.getHost();
+       }
+       // This could be the case if argument is not full URL (like "google.com" or "google.com/a/mydomain.com")
+       catch (MalformedURLException me) {
+          domainURL = "http://" + domainURL;
+          URL url = new URL(domainURL);
+          return url.getHost();
+       }
     }
 }

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/util/XMLTimeUtilUnitTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/util/XMLTimeUtilUnitTestCase.java
@@ -77,4 +77,11 @@ public class XMLTimeUtilUnitTestCase extends TestCase {
         assertTrue(XMLTimeUtil.isValid(after5M, now, after10M));
         assertFalse(XMLTimeUtil.isValid(now, after5M, after10M));
     }
+
+    public void testGMTFormat() throws Exception {
+        String now = XMLTimeUtil.getIssueInstant().toString();
+
+        assertTrue(now.endsWith("Z"));
+        assertFalse(now.contains("+"));
+    }
 }

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/util/XMLTimeUtilUnitTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/core/util/XMLTimeUtilUnitTestCase.java
@@ -21,8 +21,11 @@
  */
 package org.picketlink.test.identity.federation.core.util;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.DatatypeFactory;
@@ -31,6 +34,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import junit.framework.TestCase;
 
 import org.picketlink.identity.federation.core.saml.v2.util.XMLTimeUtil;
+import org.picketlink.identity.federation.web.constants.GeneralConstants;
 
 /**
  * Unit Test the XML Time Util
@@ -80,8 +84,14 @@ public class XMLTimeUtilUnitTestCase extends TestCase {
 
     public void testGMTFormat() throws Exception {
         String now = XMLTimeUtil.getIssueInstant().toString();
-
         assertTrue(now.endsWith("Z"));
         assertFalse(now.contains("+"));
+
+        System.setProperty(GeneralConstants.TIMEZONE, "GMT+5");
+        String now2 = XMLTimeUtil.getIssueInstant().toString();
+        assertTrue(now2.endsWith("+05:00"));
+
+        System.setProperty(GeneralConstants.TIMEZONE, GeneralConstants.TIMEZONE_DEFAULT);
+        assertEquals(XMLTimeUtil.getCurrentTimeZoneID(), TimeZone.getDefault().getID());
     }
 }

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/web/saml/handlers/SAMLIssuerTrustHandlerUnitTestCase.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/web/saml/handlers/SAMLIssuerTrustHandlerUnitTestCase.java
@@ -1,0 +1,116 @@
+/*
+ * JBoss, a division of Red Hat
+ * Copyright 2012, Red Hat Middleware, LLC, and individual
+ * contributors as indicated by the @authors tag. See the
+ * copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.picketlink.test.identity.federation.web.saml.handlers;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.picketlink.identity.federation.core.config.IDPType;
+import org.picketlink.identity.federation.core.config.TrustType;
+import org.picketlink.identity.federation.core.exceptions.ProcessingException;
+import org.picketlink.identity.federation.core.saml.v2.common.SAMLDocumentHolder;
+import org.picketlink.identity.federation.core.saml.v2.exceptions.IssuerNotTrustedException;
+import org.picketlink.identity.federation.core.saml.v2.impl.DefaultSAML2HandlerChainConfig;
+import org.picketlink.identity.federation.core.saml.v2.impl.DefaultSAML2HandlerRequest;
+import org.picketlink.identity.federation.core.saml.v2.impl.DefaultSAML2HandlerResponse;
+import org.picketlink.identity.federation.core.saml.v2.interfaces.SAML2Handler;
+import org.picketlink.identity.federation.core.saml.v2.interfaces.SAML2HandlerChainConfig;
+import org.picketlink.identity.federation.core.saml.v2.interfaces.SAML2HandlerRequest;
+import org.picketlink.identity.federation.core.saml.v2.interfaces.SAML2HandlerResponse;
+import org.picketlink.identity.federation.saml.v2.assertion.NameIDType;
+import org.picketlink.identity.federation.saml.v2.protocol.AuthnRequestType;
+import org.picketlink.identity.federation.web.constants.GeneralConstants;
+import org.picketlink.identity.federation.web.core.HTTPContext;
+import org.picketlink.identity.federation.web.handlers.saml2.SAML2IssuerTrustHandler;
+import org.picketlink.test.identity.federation.web.mock.MockHttpServletRequest;
+import org.picketlink.test.identity.federation.web.mock.MockHttpServletResponse;
+import org.picketlink.test.identity.federation.web.mock.MockHttpSession;
+import org.picketlink.test.identity.federation.web.mock.MockServletContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class SAMLIssuerTrustHandlerUnitTestCase extends TestCase {
+
+    public void testIssuer() throws Exception {
+        SAML2IssuerTrustHandler issuerTrustHandler = new SAML2IssuerTrustHandler();
+
+        // Create a Protocol Context
+        MockHttpSession session = new MockHttpSession();
+        MockServletContext servletContext = new MockServletContext();
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest(session, "POST");
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        HTTPContext httpContext = new HTTPContext(servletRequest, servletResponse, servletContext);
+
+        // Create chainConfig for IDP
+        TrustType trustType = new TrustType();
+        Map<String, Object> chainOptionsIdp = new HashMap<String, Object>();
+        IDPType idpType = new IDPType();
+        idpType.setTrust(trustType);
+        chainOptionsIdp.put(GeneralConstants.CONFIGURATION, idpType);
+        SAML2HandlerChainConfig chainConfigIdp = new DefaultSAML2HandlerChainConfig(chainOptionsIdp);
+        issuerTrustHandler.initChainConfig(chainConfigIdp);
+
+        // Create documentHolder
+        NameIDType issuer = new NameIDType();
+        AuthnRequestType authnRequestType = new AuthnRequestType("ID_123456789", null);
+        authnRequestType.setIssuer(issuer);
+        SAMLDocumentHolder documentHolder = new SAMLDocumentHolder(authnRequestType);
+
+        // Create request and response
+        SAML2HandlerRequest request = new DefaultSAML2HandlerRequest(httpContext, null, documentHolder,
+              SAML2Handler.HANDLER_TYPE.IDP);
+        SAML2HandlerResponse response = new DefaultSAML2HandlerResponse();
+
+        // Test localhost
+        issuer.setValue("http://localhost:8080/sales");
+        trustType.setDomains("localhost,google.com,somedomain.com");
+        issuerTrustHandler.handleRequestType(request, response);
+
+        // Test somedomain
+        issuer.setValue("http://www.somedomain.com:8080/sales/");
+        issuerTrustHandler.handleRequestType(request, response);
+
+        // Test non-trusted domain
+        try {
+            issuer.setValue("http://www.evil.com:8080/sales/");
+            issuerTrustHandler.handleRequestType(request, response);
+
+            fail("www.evil.com is non-trusted domain");
+        }
+        catch (ProcessingException pe) {
+            Assert.assertEquals(pe.getCause().getClass(), IssuerNotTrustedException.class);
+        }
+
+        // Test google.com
+        issuer.setValue("google.com");
+        issuerTrustHandler.handleRequestType(request, response);
+
+        issuer.setValue("google.com/a/mposolda1.com");
+        issuerTrustHandler.handleRequestType(request, response);
+    }
+
+}


### PR DESCRIPTION
PLFED-340:
I changed method SAML2IssuerTrustHandler.getDomain() to understand situation when protocol prefix is not added. And I added new unit test SAMLIssuerTrustHandlerUnitTestCase for it.

PLFED-341:
I changed XMLTimeUtil.getIssueInstant() to always use GMT timezone like:
TimeZone.getTimeZone("GMT").getID();

instead of default system timezone like:
TimeZone.getDefault().getID();

I also added unit test.

Maybe it can be configurable, but I don't think that it's necessary at this moment. And I am not seeing any disadvantage with using GMT timezone by default.
