### PR TITLE
Changed to consider the request.getMethod during the saml token retrieving/parsing. Instead of idpUsesPostBinding.

### DIFF
--- a/picketlink-bindings/picketlink-tomcat-common/src/main/java/org/picketlink/identity/federation/bindings/tomcat/sp/AbstractSPFormAuthenticator.java
+++ b/picketlink-bindings/picketlink-tomcat-common/src/main/java/org/picketlink/identity/federation/bindings/tomcat/sp/AbstractSPFormAuthenticator.java
@@ -360,7 +360,7 @@ public abstract class AbstractSPFormAuthenticator extends BaseFormAuthenticator 
 
         try {
             ServiceProviderSAMLRequestProcessor requestProcessor = new ServiceProviderSAMLRequestProcessor(
-                    isPOSTBindingResponse(), this.serviceURL);
+                    request.getMethod().equals("POST"), this.serviceURL);
             requestProcessor.setTrustKeyManager(keyManager);
             requestProcessor.setConfiguration(spConfiguration);
             boolean result = requestProcessor.process(samlRequest, httpContext, handlers, chainLock);

--- a/picketlink-bindings/picketlink-tomcat5/src/test/java/org/picketlink/test/identity/federation/bindings/workflow/SAML2LogoutTomcatWorkflowUnitTestCase.java
+++ b/picketlink-bindings/picketlink-tomcat5/src/test/java/org/picketlink/test/identity/federation/bindings/workflow/SAML2LogoutTomcatWorkflowUnitTestCase.java
@@ -225,6 +225,7 @@ public class SAML2LogoutTomcatWorkflowUnitTestCase {
 
         request = new MockCatalinaRequest();
         request.setSession(session);
+        request.setMethod("GET");
         request.setParameter("SAMLRequest", RedirectBindingUtil.urlDecode(logoutRequest));
         request.setParameter("RelayState", relayState);
 


### PR DESCRIPTION
...ng/parsing. Instead of idpUsesPostBinding.
