### PR TITLE
Add AuthnStatement in generated SAML v2 tokens.

### DIFF
--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/core/wstrust/plugins/saml/SAML20TokenProvider.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/core/wstrust/plugins/saml/SAML20TokenProvider.java
@@ -179,6 +179,9 @@ public class SAML20TokenProvider extends AbstractSecurityTokenProvider implement
             statements.add(StatementUtil.createAttributeStatement(claimedAttributes));
         }
 
+        // create an AuthnStatement
+        statements.add(StatementUtil.createAuthnStatement(lifetime.getCreated(), confirmationMethod));
+
         // create the SAML assertion.
         NameIDType issuerID = SAMLAssertionFactory.createNameID(null, null, context.getTokenIssuer());
         AssertionType assertion = SAMLAssertionFactory.createAssertion(assertionID, issuerID, lifetime.getCreated(),


### PR DESCRIPTION
Using Picketlink STS to generate SAML 2.0 token for ADFS ended up showing issues when those tokens got converted to SAML v1 (typically for Office 365 federated authentication). The required element in SAML 1.1 is "AuthenticationStatement"
This patch adds the creation of an "AuthnStatement" when using the SAML20TokenProvider, which is in turn converted into an "AuthenticationStatement" when conversion to SAML 1.1 occurs.

The token created using this patch were successfully tested to go through ADFS and allow proper authentication on Office 365.
