### PR TITLE
Use requested URL for AssertionConsumerServiceURL value in SAML Request document

### DIFF
--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/web/handlers/saml2/SAML2AuthenticationHandler.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/web/handlers/saml2/SAML2AuthenticationHandler.java
@@ -348,7 +348,16 @@ public class SAML2AuthenticationHandler extends BaseSAML2Handler {
             SAML2Request samlRequest = new SAML2Request();
             String id = IDGenerator.create("ID_");
 
-            String assertionConsumerURL = (String) handlerConfig.getParameter(SAML2Handler.ASSERTION_CONSUMER_URL);
+            // Use the requested URL first, before falling back to issuer or configured url.
+            HTTPContext httpContext = (HTTPContext) request.getContext();
+            String assertionConsumerURL = httpContext.getRequest().getRequestURL().toString();
+            if ( httpContext.getRequest().getQueryString() != null)
+            {
+            	assertionConsumerURL = assertionConsumerURL + "?" + httpContext.getRequest().getQueryString();
+            }
+            if (StringUtil.isNullOrEmpty(assertionConsumerURL)) {
+            	assertionConsumerURL = (String) handlerConfig.getParameter(SAML2Handler.ASSERTION_CONSUMER_URL);
+            }
             if (StringUtil.isNullOrEmpty(assertionConsumerURL)) {
                 assertionConsumerURL = issuerValue;
             }

--- a/picketlink-core/src/test/java/org/picketlink/test/identity/federation/web/mock/MockHttpServletRequest.java
+++ b/picketlink-core/src/test/java/org/picketlink/test/identity/federation/web/mock/MockHttpServletRequest.java
@@ -63,6 +63,8 @@ public class MockHttpServletRequest implements HttpServletRequest {
     private String methodType;
 
     private String queryString;
+    
+    private StringBuffer urlBuffer;
 
     public MockHttpServletRequest(HttpSession session, String methodType) {
         this.session = session;
@@ -159,9 +161,12 @@ public class MockHttpServletRequest implements HttpServletRequest {
         throw new RuntimeException("NYI");
     }
 
+    public void setRequestURL(StringBuffer urlBuffer) {
+    	this.urlBuffer = urlBuffer;
+    }
+    
     public StringBuffer getRequestURL() {
-
-        throw new RuntimeException("NYI");
+    	return urlBuffer;
     }
 
     public String getRequestedSessionId() {
@@ -394,7 +399,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
         return null;
     }
 
-    @Override
+    //@Override
     public Part getPart(String name) throws IOException, ServletException {
         return null;
     }


### PR DESCRIPTION
Includes unit test case, and additional methods in MockHttpServletRequest class to support test case.
