### PR TITLE
SAML 1.1 Post Profile

### DIFF
--- a/picketlink-bindings/picketlink-tomcat5/src/main/java/org/picketlink/identity/federation/bindings/tomcat/sp/SAML11SPPostFormAuthenticator.java
+++ b/picketlink-bindings/picketlink-tomcat5/src/main/java/org/picketlink/identity/federation/bindings/tomcat/sp/SAML11SPPostFormAuthenticator.java
@@ -1,0 +1,138 @@
+package org.picketlink.identity.federation.bindings.tomcat.sp;
+
+import static org.picketlink.identity.federation.core.util.StringUtil.isNotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.Session;
+import org.apache.catalina.authenticator.Constants;
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.catalina.deploy.LoginConfig;
+import org.picketlink.identity.federation.bindings.tomcat.sp.holder.ServiceProviderSAMLContext;
+import org.picketlink.identity.federation.core.ErrorCodes;
+import org.picketlink.identity.federation.core.parsers.saml.SAMLParser;
+import org.picketlink.identity.federation.core.saml.v2.util.AssertionUtil;
+import org.picketlink.identity.federation.saml.v1.assertion.SAML11AssertionType;
+import org.picketlink.identity.federation.saml.v1.assertion.SAML11AuthenticationStatementType;
+import org.picketlink.identity.federation.saml.v1.assertion.SAML11StatementAbstractType;
+import org.picketlink.identity.federation.saml.v1.assertion.SAML11SubjectType;
+import org.picketlink.identity.federation.saml.v1.protocol.SAML11ResponseType;
+import org.picketlink.identity.federation.web.constants.GeneralConstants;
+import org.picketlink.identity.federation.web.util.PostBindingUtil;
+import org.picketlink.identity.federation.web.util.ServerDetector;
+
+/**
+ * Authenticator for SAML 1.1 processing using post profile.
+ */
+public class SAML11SPPostFormAuthenticator extends AbstractSPFormAuthenticator {
+
+    @Override
+    public boolean authenticate(Request request, Response response, LoginConfig loginConfig) throws IOException {
+        String samlResponse = request.getParameter(GeneralConstants.SAML_RESPONSE_KEY);
+
+        Principal principal = request.getUserPrincipal();
+
+        // If we have already authenticated the user and there is no request from IDP or logout from user
+        if (principal != null)
+            return true;
+
+        Session session = request.getSessionInternal(true);
+
+        // See if we got a response from IDP
+        if (isNotNull(samlResponse)) {
+            boolean isValid = false;
+            try {
+                isValid = this.validate(request);
+            } catch (Exception e) {
+                logger.samlSPHandleRequestError(e);
+                throw new IOException();
+            }
+            if (!isValid)
+                throw new IOException(ErrorCodes.VALIDATION_CHECK_FAILED);
+
+            try {
+                InputStream base64DecodedResponse = PostBindingUtil.base64DecodeAsStream(samlResponse);
+                SAMLParser parser = new SAMLParser();
+                SAML11ResponseType saml11Response = (SAML11ResponseType) parser.parse(base64DecodedResponse);
+
+                List<SAML11AssertionType> assertions = saml11Response.get();
+                if (assertions.size() > 1) {
+                    logger.trace("More than one assertion from IDP. Considering the first one.");
+                }
+                String username = null;
+                List<String> roles = new ArrayList<String>();
+                SAML11AssertionType assertion = assertions.get(0);
+                if (assertion != null) {
+                    // Get the subject
+                    List<SAML11StatementAbstractType> statements = assertion.getStatements();
+                    for (SAML11StatementAbstractType statement : statements) {
+                        if (statement instanceof SAML11AuthenticationStatementType) {
+                            SAML11AuthenticationStatementType subStat = (SAML11AuthenticationStatementType) statement;
+                            SAML11SubjectType subject = subStat.getSubject();
+                            username = subject.getChoice().getNameID().getValue();
+                        }
+                    }
+                    roles = AssertionUtil.getRoles(assertion, null);
+                }
+
+                String password = ServiceProviderSAMLContext.EMPTY_PASSWORD;
+
+                // Map to JBoss specific principal
+                if ((new ServerDetector()).isJboss() || jbossEnv) {
+                    // Push a context
+                    ServiceProviderSAMLContext.push(username, roles);
+                    principal = context.getRealm().authenticate(username, password);
+                    ServiceProviderSAMLContext.clear();
+                } else {
+                    // tomcat env
+                    SPUtil spUtil = new SPUtil();
+                    principal = spUtil.createGenericPrincipal(request, username, roles);
+                }
+
+                session.setNote(Constants.SESS_USERNAME_NOTE, username);
+                session.setNote(Constants.SESS_PASSWORD_NOTE, password);
+                request.setUserPrincipal(principal);
+
+                if (saveRestoreRequest) {
+                    this.restoreRequest(request, session);
+                }
+                register(request, response, principal, Constants.FORM_METHOD, username, password);
+
+                return true;
+            } catch (Exception e) {
+                logger.samlSPHandleRequestError(e);
+            }
+        }
+
+        logger.trace("Falling back on local Form Authentication if available");
+        // fallback
+        return super.authenticate(request, response, loginConfig);
+    }	
+	
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.picketlink.identity.federation.bindings.tomcat.sp.BaseFormAuthenticator#start()
+     */
+    @Override
+    public void start() throws LifecycleException {
+        super.start();
+        startPicketLink();
+    }
+
+    public void testStart() throws LifecycleException {
+        super.testStart();
+        startPicketLink();
+    }
+
+    @Override
+    protected String getContextPath() {
+        return getContext().getServletContext().getContextPath();
+    }
+}

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/core/saml/v1/SAML11Constants.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/core/saml/v1/SAML11Constants.java
@@ -80,6 +80,8 @@ public interface SAML11Constants {
 
     String DNS_ADDRESS = "DNSAddress";
 
+    String ENDPOINT = "ENDPOINT";
+
     String EVIDENCE = "Evidence";
 
     String FORMAT = "Format";

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/core/saml/v2/holders/DestinationInfoHolder.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/core/saml/v2/holders/DestinationInfoHolder.java
@@ -31,18 +31,33 @@ public class DestinationInfoHolder {
     private String destination;
     private String samlMessage;
     private String relayState;
+    private String target;
 
     /**
      * Create an holder
      *
      * @param destination The destination where the post will be sent
      * @param samlMessage SAML Message
-     * @param relayState
+     * @param relayState 
      */
     public DestinationInfoHolder(String destination, String samlMessage, String relayState) {
         this.destination = destination;
         this.samlMessage = samlMessage;
         this.relayState = relayState;
+    }
+    
+    /**
+     * Create an holder
+     *
+     * @param destination The destination where the post will be sent
+     * @param samlMessage SAML Message
+     * @param relayState 
+     * @param target this is for SAMLv11 where the relayState is named target
+     */
+    public DestinationInfoHolder(String destination, String samlMessage, String relayState, String target) {
+    	this(destination, samlMessage, relayState);
+    	
+        this.target = target;
     }
 
     public String getDestination() {
@@ -55,5 +70,9 @@ public class DestinationInfoHolder {
 
     public String getRelayState() {
         return relayState;
+    }
+    
+    public String getTarget() {
+    	return target;
     }
 }

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/web/util/IDPWebRequestUtil.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/web/util/IDPWebRequestUtil.java
@@ -195,6 +195,7 @@ public class IDPWebRequestUtil {
 
         String destination = holder.getDestination();
         String relayState = holder.getRelayState();
+        String target = holder.getTarget();
         boolean supportSignature = holder.isSupportSignature();
         boolean sendRequest = holder.isAreWeSendingRequest();
         HttpServletResponse response = holder.getServletResponse();
@@ -231,7 +232,7 @@ public class IDPWebRequestUtil {
 
             String samlResponse = PostBindingUtil.base64Encode(new String(responseBytes));
 
-            PostBindingUtil.sendPost(new DestinationInfoHolder(destination, samlResponse, relayState), response, sendRequest);
+            PostBindingUtil.sendPost(new DestinationInfoHolder(destination, samlResponse, relayState, target), response, sendRequest);
         }
     }
 
@@ -347,6 +348,8 @@ public class IDPWebRequestUtil {
         private Document responseDoc;
 
         private String relayState;
+        
+        private String target;
 
         private String destination;
 
@@ -392,6 +395,15 @@ public class IDPWebRequestUtil {
         public WebRequestUtilHolder setRelayState(String relayState) {
             this.relayState = relayState;
             return this;
+        }
+        
+        public WebRequestUtilHolder setTarget(String target) {
+           this.target = target;
+           return this;
+        }
+        
+        public String getTarget() {
+        	return target;
         }
 
         public String getDestination() {

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/web/util/PostBindingUtil.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/web/util/PostBindingUtil.java
@@ -94,6 +94,7 @@ public class PostBindingUtil {
         String key = request ? GeneralConstants.SAML_REQUEST_KEY : GeneralConstants.SAML_RESPONSE_KEY;
 
         String relayState = holder.getRelayState();
+        String target = holder.getTarget();
         String destination = holder.getDestination();
         String samlMessage = holder.getSamlMessage();
 
@@ -119,6 +120,9 @@ public class PostBindingUtil {
         builder.append("<INPUT TYPE=\"HIDDEN\" NAME=\"" + key + "\"" + " VALUE=\"" + samlMessage + "\"/>");
         if (isNotNull(relayState)) {
             builder.append("<INPUT TYPE=\"HIDDEN\" NAME=\"RelayState\" " + "VALUE=\"" + relayState + "\"/>");
+        }
+        if (isNotNull(target)) {
+        	builder.append("<INPUT TYPE=\"HIDDEN\" NAME=\"TARGET\" " + "VALUE=\"" + target + "\"/>");
         }
         builder.append("</FORM></BODY></HTML>");
 


### PR DESCRIPTION
These changes are for supporting SAML 1.1 Post Profile.  If approved, I will add/change the picketlink-quickstarts and work on the signature support as well.  Thanks.

picketlink-bindings/picketlink-tomcat-common/src/main/java/org/picketlink/identity/federation/bindings/tomcat/idp/AbstractIDPValve.java:
- Put an end point where the SAMLResponse is going to be posted.
- Make target as the final destination (RelayState in SAMLv2).
- Added confirmation method in SubjectConfirmation per the standard post
  profile.
- Set the recipient in the SAML11Response again per the standard.
- Use the strict post binding flag for post binding requested of the
  holder.  With this, if strict post binding flag is false then it will be
  just the redirect (GET).

picketlink-core/src/main/java/org/picketlink/identity/federation/core/saml/v1/SAML11Constants.java
- Added constant for end point

picketlink-core/src/main/java/org/picketlink/identity/federation/core/saml/v2/holders/DestinationInfoHolder.java
- Added target property and corresponding constructor and getter

picketlink-core/src/main/java/org/picketlink/identity/federation/web/util/IDPWebRequestUtil.java
- Process the target property
- Changed the constructor to include target property
- Add builder method for target property

picketlink-core/src/main/java/org/picketlink/identity/federation/web/util/PostBindingUtil.java
- If the holder contains target then it will use target instead of
  relayState.

picketlink-bindings/picketlink-tomcat5/src/main/java/org/picketlink/identity/federation/bindings/tomcat/sp/SAML11SPPostFormAuthenticator.java
- SP Authenticator for handling post changes from IdP
