### PR TITLE
[PLINK2-25] characterEncoding parameter not used in for Post Requests in...

### DIFF
--- a/picketlink-bindings/picketlink-tomcat-common/src/main/java/org/picketlink/identity/federation/bindings/tomcat/sp/AbstractSPFormAuthenticator.java
+++ b/picketlink-bindings/picketlink-tomcat-common/src/main/java/org/picketlink/identity/federation/bindings/tomcat/sp/AbstractSPFormAuthenticator.java
@@ -264,6 +264,12 @@ public abstract class AbstractSPFormAuthenticator extends BaseFormAuthenticator 
     @Override
     public boolean authenticate(Request request, Response response, LoginConfig loginConfig) throws IOException {
         try {
+            // needs to be done first, *before* accessing any parameters. super.authenticate(..) gets called to late
+            String characterEncoding = getCharacterEncoding();
+            if (characterEncoding != null) {
+                request.setCharacterEncoding(characterEncoding);
+            }
+
             Session session = request.getSessionInternal(true);
 
             // check if this call is resulting from the redirect after successful authentication.


### PR DESCRIPTION
... ServiceProviderAuthenticator

https://issues.jboss.org/browse/PLINK2-25

fixed by making sure the PL authenticate(..) calls setCharacterEncoding(..) _before_ reading the SAML parameters from the request.
