### PR TITLE
added RequestedAuthnContext to sp AuthnRequest https://issues.jboss.org/browse/PRODMGT-503

### DIFF
--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/core/parsers/saml/SAMLAuthNRequestParser.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/core/parsers/saml/SAMLAuthNRequestParser.java
@@ -171,12 +171,21 @@ public class SAMLAuthNRequestParser extends SAMLRequestAbstractParser implements
 
         startElement = StaxParserUtil.getNextStartElement(xmlEventReader);
         String elName = StaxParserUtil.getStartElementName(startElement);
-
-        if (elName.equals(JBossSAMLConstants.AUTHN_CONTEXT_CLASS_REF.get())) {
+        
+        if(!elName.equals(JBossSAMLConstants.AUTHN_CONTEXT_CLASS_REF.get())) {
+            throw new RuntimeException(ErrorCodes.EXPECTED_TAG + JBossSAMLConstants.AUTHN_CONTEXT_CLASS_REF.get());
+        }
+        
+        while (elName.equals(JBossSAMLConstants.AUTHN_CONTEXT_CLASS_REF.get())) {
             String value = StaxParserUtil.getElementText(xmlEventReader);
             ract.addAuthnContextClassRef(value);
-        } else
-            throw new RuntimeException(ErrorCodes.UNKNOWN_TAG + elName);
+            
+            startElement = StaxParserUtil.getNextStartElement(xmlEventReader);
+            if(startElement == null) {
+            	break;
+            }
+            elName = StaxParserUtil.getStartElementName(startElement);
+        }
 
         return ract;
     }

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/core/saml/v2/constants/JBossSAMLConstants.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/core/saml/v2/constants/JBossSAMLConstants.java
@@ -41,7 +41,7 @@ public enum JBossSAMLConstants {
             "AuthnContextClassRef"), AUTHN_CONTEXT_DECLARATION("AuthnContextDecl"), AUTHN_CONTEXT_DECLARATION_REF(
             "AuthnContextDeclRef"), AUTHN_INSTANT("AuthnInstant"), AUTHN_REQUEST("AuthnRequest"), AUTHN_STATEMENT(
             "AuthnStatement"), AUTHN_REQUESTS_SIGNED("AuthnRequestsSigned"), BASEID("BaseID"), BINDING("Binding"), CACHE_DURATION(
-            "cacheDuration"), COMPANY("Company"), CONDITIONS("Conditions"), CONSENT("Consent"), CONTACT_PERSON("ContactPerson"), CONTACT_TYPE(
+            "cacheDuration"), COMPANY("Company"), COMPARISON("Comparison"), CONDITIONS("Conditions"), CONSENT("Consent"), CONTACT_PERSON("ContactPerson"), CONTACT_TYPE(
             "contactType"), DESTINATION("Destination"), DNS_NAME("DNSName"), EMAIL_ADDRESS("EmailAddress"), ENCODING("Encoding"), ENCRYPTED_ASSERTION(
             "EncryptedAssertion"), ENCRYPTED_ID("EncryptedID"), ENTITY_ID("entityID"), ENTITY_DESCRIPTOR("EntityDescriptor"), ENTITIES_DESCRIPTOR(
             "EntitiesDescriptor"), EXTENSIONS("Extensions"), FORMAT("Format"), FRIENDLY_NAME("FriendlyName"), FORCE_AUTHN(

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/core/saml/v2/writers/SAMLRequestWriter.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/core/saml/v2/writers/SAMLRequestWriter.java
@@ -52,6 +52,7 @@ import org.picketlink.identity.federation.saml.v2.protocol.AttributeQueryType;
 import org.picketlink.identity.federation.saml.v2.protocol.AuthnRequestType;
 import org.picketlink.identity.federation.saml.v2.protocol.LogoutRequestType;
 import org.picketlink.identity.federation.saml.v2.protocol.NameIDPolicyType;
+import org.picketlink.identity.federation.saml.v2.protocol.RequestedAuthnContextType;
 import org.picketlink.identity.federation.saml.v2.protocol.XACMLAuthzDecisionQueryType;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -135,6 +136,11 @@ public class SAMLRequestWriter extends BaseWriter {
         Element sig = request.getSignature();
         if (sig != null) {
             StaxUtil.writeDOMElement(writer, sig);
+        }
+        
+        RequestedAuthnContextType requestedAuthnContext = request.getRequestedAuthnContext();
+        if(requestedAuthnContext != null) {
+        	write(requestedAuthnContext);
         }
 
         NameIDPolicyType nameIDPolicy = request.getNameIDPolicy();
@@ -227,6 +233,32 @@ public class SAMLRequestWriter extends BaseWriter {
 
         StaxUtil.writeEndElement(writer);
         StaxUtil.flush(writer);
+    }
+    
+    public void write(RequestedAuthnContextType authnContextType) throws ProcessingException {
+    	
+    	if(authnContextType != null) {
+    		
+	    	StaxUtil.writeStartElement(writer, PROTOCOL_PREFIX, JBossSAMLConstants.REQUESTED_AUTHN_CONTEXT.get(), PROTOCOL_NSURI.get());
+	    	if(authnContextType.getComparison() != null) {
+	    		StaxUtil.writeAttribute(writer, JBossSAMLConstants.COMPARISON.get(), authnContextType.getComparison().value());
+	    	} 
+	    	
+	    	if(authnContextType.getAuthnContextClassRef() != null && authnContextType.getAuthnContextClassRef().size() != 0) {
+	    		for(String type : authnContextType.getAuthnContextClassRef()) {
+		    		StaxUtil.writeStartElement(writer, ASSERTION_PREFIX, JBossSAMLConstants.AUTHN_CONTEXT_CLASS_REF.get(), ASSERTION_NSURI.get());
+		    		StaxUtil.writeNameSpace(writer, ASSERTION_PREFIX, ASSERTION_NSURI.get());
+			    	StaxUtil.writeCharacters(writer, type);
+			    	StaxUtil.writeEndElement(writer);
+		    	}
+	    	}
+	    	
+	    	
+	    	StaxUtil.writeEndElement(writer);
+    	}
+    	
+    	
+    	
     }
 
     public void write(ArtifactResolveType request) throws ProcessingException {

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/web/constants/GeneralConstants.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/web/constants/GeneralConstants.java
@@ -141,4 +141,6 @@ public interface GeneralConstants {
      * <p>{@link SAML2AuthenticationHandler} configuration option to set the assertion into the {@link HttpSession}.</p>
      */
     String ASSERTION_SESSION_ATTRIBUTE_NAME = "ASSERTION_SESSION_ATTRIBUTE_NAME";
+    String AUTHN_CONTEXT_CLASS_REF = "AUTHN_CONTEXT_CLASS_REF";
+	String AUTHN_CONTEXT_COMPARISON = "AUTHN_CONTEXT_COMPARISON";
 }

--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/web/handlers/saml2/SAML2AuthenticationHandler.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/web/handlers/saml2/SAML2AuthenticationHandler.java
@@ -76,6 +76,8 @@ import org.picketlink.identity.federation.saml.v2.assertion.SubjectType.STSubTyp
 import org.picketlink.identity.federation.saml.v2.metadata.EndpointType;
 import org.picketlink.identity.federation.saml.v2.metadata.SPSSODescriptorType;
 import org.picketlink.identity.federation.saml.v2.protocol.AuthnRequestType;
+import org.picketlink.identity.federation.saml.v2.protocol.RequestedAuthnContextType;
+import org.picketlink.identity.federation.saml.v2.protocol.AuthnContextComparisonType;
 import org.picketlink.identity.federation.saml.v2.protocol.ResponseType;
 import org.picketlink.identity.federation.saml.v2.protocol.ResponseType.RTChoiceType;
 import org.picketlink.identity.federation.saml.v2.protocol.StatusType;
@@ -375,6 +377,25 @@ public class SAML2AuthenticationHandler extends BaseSAML2Handler {
 
                 String bindingType = getSPConfiguration().getBindingType();
                 boolean isIdpUsesPostBinding = getSPConfiguration().isIdpUsesPostBinding();
+                
+                //setting authnContextClassRef if it's configured
+                String authnContextClassRef = (String) handlerConfig.getParameter(GeneralConstants.AUTHN_CONTEXT_CLASS_REF);
+                if(StringUtil.isNotNull(authnContextClassRef)) {
+                	RequestedAuthnContextType authnContext = new RequestedAuthnContextType();
+                	String[] contexts = authnContextClassRef.split(",");
+                	
+                	for(String context: contexts) {
+                		authnContext.addAuthnContextClassRef(context);
+                	}
+                	
+                	
+                	String authnContextComparison = (String) handlerConfig.getParameter(GeneralConstants.AUTHN_CONTEXT_COMPARISON);
+                	if(authnContextComparison != null) {
+                		authnContext.setComparison(AuthnContextComparisonType.fromValue(authnContextComparison));
+                	}
+                	
+                	authn.setRequestedAuthnContext(authnContext);
+                }
 
                 if (bindingType != null) {
                     if (bindingType.equals("POST") || isIdpUsesPostBinding) {


### PR DESCRIPTION
Example Configuration:

``` xml
      <Handler  class="org.picketlink.identity.federation.web.handlers.saml2.SAML2AuthenticationHandler">
         <Option Key="AUTHN_CONTEXT_CLASS_REF" Value="urn:oasis:names:tc:SAML:2.0:ac:classes:Password:JBoss,urn:oasis:names:tc:SAML:2.0:ac:classes:Password:JBoss2" />
             <Option Key="AUTHN_CONTEXT_COMPARISON" Value="exact" />
      </Handler>
```

Comma separated class refs and comparison value as described in the standard (“better” | “exact” | “maximum” | “minimum”). Comparison is optional also if you set AUTHN_CONTEXT_CLASS_REF.

Example authnRequest obtained from the configuration:

``` xml
    <samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
                    xmlns="urn:oasis:names:tc:SAML:2.0:assertion"
                    AssertionConsumerServiceURL="http://jboss-eap6.corp.generalisvil.net:8180/wsweb/"
                    Destination="https://namx.corp.generalisvil.net/nidp/saml2/sso"
                    ID="ID_dcb979ba-1681-4b2b-b8cb-ae5427789922"
                    IssueInstant="2013-08-26T20:42:30.980Z"
                    ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
                    Version="2.0"
                    >
        <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">http://jboss-eap6.corp.generalisvil.net:8180/wsweb/</saml:Issuer>
        <dsig:Signature xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
            <dsig:SignedInfo>
                <dsig:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#WithComments" />
                <dsig:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" />
                 <dsig:Reference URI="#ID_dcb979ba-1681-4b2b-b8cb-ae5427789922">
                <dsig:Transforms>
                    <dsig:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
                    <dsig:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
                </dsig:Transforms>
                <dsig:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
                <dsig:DigestValue>QpZl7ctT2IN8ejiHtXGrSTdSQvU=</dsig:DigestValue>
            </dsig:Reference>
        </dsig:SignedInfo>
        <dsig:SignatureValue>XSGOA4VhMVryJuyooRIhyjMHYruryxCAjKGEwbUZ7d429xRq7W0u7NUHvTXm7TMFreas+1rW5fU0OIf8aUq9zltVN6mjGK52csRGvmtXOd1PL1phS2sSplXt2Xxlra5cyv6bjMkbWa04me+K80frAD7WJlco7bcB78dqFFlD1PZ79G8s/WUmp5K2nSav1g967aSZHhyIzVBy4IxhzdGqJv5VLWknZzH18pFTxa+wGiXjGg2CYtuKSnc2D+X6CW02xJ8OfSJeexpQkk8RcbD3LM8cArBqD7Nb1EpZ5aXs6PDkC/8Nw1IrZK2IYI+Yop3hsnMhlw4esJ7t9EEybnKeOA==</dsig:SignatureValue>
        <dsig:KeyInfo>
            <dsig:KeyValue>
                <dsig:RSAKeyValue>
                    <dsig:Modulus>1Z+gdQhFcwaqFCCokxx6+usSrdNFtj64bkMvjnhXVS+GqB6BCXvQWjQROYEV2Yb24UH2+NpyUyMMWKgx7tWPGr+omoOgY10Tqd7OsMyXkuiPkTDiwPrekM1cxYbEIkyK0rRXXek4w1U2ozha0gJhKLrAh9LnPBFezQWrKa8cYAYBV3hb4zWfJLzQsj01N+WBhP1tX0aJ8X+bIiE7IhqkhxYRu4z8H0n0WReHzp9BvzsOxIPYMu7XF92vsdvhnm1FdCP0famwANrJRp2FKi9pv/ktW1OZRl4227+W1ztVo83CliodLo3gSCZE19BzHGFYAJKX/nVd58g/uUFX+7bPow==</dsig:Modulus>
                    <dsig:Exponent>AQAB</dsig:Exponent>
                </dsig:RSAKeyValue>
            </dsig:KeyValue>
        </dsig:KeyInfo>
    </dsig:Signature>
    <samlp:RequestedAuthnContext Comparison="exact">
        <saml:AuthnContextClassRef xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">urn:oasis:names:tc:SAML:2.0:ac:classes:Password:JBoss</saml:AuthnContextClassRef>
        <saml:AuthnContextClassRef xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">urn:oasis:names:tc:SAML:2.0:ac:classes:Password:JBoss2</saml:AuthnContextClassRef>
    </samlp:RequestedAuthnContext>
</samlp:AuthnRequest>
```
