### PR TITLE
[bz-1072387]  IdP does not redirect back to original SP URL when accessed via SP URL

### DIFF
--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/web/util/HTTPRedirectUtil.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/web/util/HTTPRedirectUtil.java
@@ -61,7 +61,6 @@ public class HTTPRedirectUtil {
     }
 
     private static void sendRedirect(HttpServletResponse response, String destination) throws IOException {
-        response.reset();
         response.setStatus(HttpServletResponse.SC_MOVED_TEMPORARILY);
         response.sendRedirect(destination);
     }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1072387

backported https://issues.jboss.org/browse/PLINK-379 into "master" branch for PL 2.1.x
