### PR TITLE
[JBPAPP-11080], backport fix of [BZ1064331] NPE in JBWSTokenIssuingLoginModule.

### DIFF
--- a/picketlink-core/src/main/java/org/picketlink/identity/federation/core/wstrust/STSClientFactory.java
+++ b/picketlink-core/src/main/java/org/picketlink/identity/federation/core/wstrust/STSClientFactory.java
@@ -65,7 +65,7 @@ public final class STSClientFactory {
 
     public STSClient create(int initialNumberOfClients, final STSClientCreationCallBack callBack) {
         if (POOL.isPoolingDisabled()) {
-            return null;
+            return callBack.createClient();
         }
         POOL.initialize(initialNumberOfClients, callBack);
         return POOL.takeOut(callBack.getKey());


### PR DESCRIPTION
https://issues.jboss.org/browse/JBPAPP-11080
Backport  upstream fix of [BZ1064331] "NPE in JBWSTokenIssuingLoginModule"
https://bugzilla.redhat.com/show_bug.cgi?id=1064331
